### PR TITLE
Update docs/examples to use `.as_raw_fd()` instead of `.into_raw_fd()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ use libdrm_amdgpu_sys::AMDGPU::GPU_INFO;
 let libdrm_amdgpu = LibDrmAmdgpu::new().unwrap();
 let (amdgpu_dev, drm_major, drm_minor) = {
     use std::fs::OpenOptions;
-    use std::os::fd::IntoRawFd;
+    use std::os::fd::AsRawFd;
 
     let fd = OpenOptions::new().read(true).write(true).open("/dev/dri/renderD128").unwrap();
 
-    libdrm_amdgpu.init_device_handle(fd.into_raw_fd()).unwrap()
+    libdrm_amdgpu.init_device_handle(fd.as_raw_fd()).unwrap()
 };
 let device_info = amdgpu_dev.device_info().unwrap();
 let device_name = device_info.find_device_name_or_default();

--- a/amdgpu/mod.rs
+++ b/amdgpu/mod.rs
@@ -93,11 +93,11 @@ pub mod VBIOS {
 /// let libdrm_amdgpu = LibDrmAmdgpu::new().unwrap();
 /// let (amdgpu_dev, drm_major, drm_minor) = {
 ///     use std::fs::File;
-///     use std::os::fd::IntoRawFd;
+///     use std::os::fd::AsRawFd;
 ///
 ///     let fd = File::open("/dev/dri/renderD128").unwrap();
 ///
-///     libdrm_amdgpu.init_device_handle(fd.into_raw_fd()).unwrap()
+///     libdrm_amdgpu.init_device_handle(fd.as_raw_fd()).unwrap()
 /// };
 /// for cap_type in [
 ///     amdgpu_dev.get_video_caps(CAP_TYPE::DECODE).unwrap(),

--- a/examples/amdgpu_info.rs
+++ b/examples/amdgpu_info.rs
@@ -4,11 +4,11 @@ fn info(libdrm_amdgpu: &LibDrmAmdgpu, pci_bus: &PCI::BUS_INFO) {
     let Ok(device_path) = pci_bus.get_drm_render_path() else { return };
     let (amdgpu_dev, _major, _minor) = {
         use std::fs::File;
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let fd = File::open(device_path).unwrap();
 
-        libdrm_amdgpu.init_device_handle(fd.into_raw_fd()).unwrap()
+        libdrm_amdgpu.init_device_handle(fd.as_raw_fd()).unwrap()
     };
 
     if let Ok(drm_ver) = amdgpu_dev.get_drm_version_struct() {

--- a/examples/drm_mode.rs
+++ b/examples/drm_mode.rs
@@ -1,13 +1,13 @@
-use libdrm_amdgpu_sys::{drmModePropType, LibDrm};
+use libdrm_amdgpu_sys::{LibDrm, drmModePropType};
 use std::fs::File;
 
 fn main() {
     let fd = {
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let f = File::open("/dev/dri/card0").unwrap();
 
-        f.into_raw_fd()
+        f.as_raw_fd()
     };
 
     let libdrm = LibDrm::new().unwrap();

--- a/examples/gpu_metrics.rs
+++ b/examples/gpu_metrics.rs
@@ -6,11 +6,11 @@ fn main() {
     let libdrm_amdgpu = LibDrmAmdgpu::new().unwrap();
     let device_path = std::env::var("AMDGPU_PATH").unwrap_or("/dev/dri/renderD128".to_string());
     let (amdgpu_dev, _, _) = {
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let f = File::open(device_path).unwrap();
 
-        libdrm_amdgpu.init_device_handle(f.into_raw_fd()).unwrap()
+        libdrm_amdgpu.init_device_handle(f.as_raw_fd()).unwrap()
     };
 
     let path = amdgpu_dev.get_sysfs_path().unwrap();

--- a/examples/ip_discovery.rs
+++ b/examples/ip_discovery.rs
@@ -1,16 +1,16 @@
-use libdrm_amdgpu_sys::LibDrmAmdgpu;
 use libdrm_amdgpu_sys::AMDGPU::{self, IpDieEntry};
+use libdrm_amdgpu_sys::LibDrmAmdgpu;
 use std::fs::File;
 
 fn main() {
     let libdrm_amdgpu = LibDrmAmdgpu::new().unwrap();
     let device_path = std::env::var("AMDGPU_PATH").unwrap_or("/dev/dri/renderD128".to_string());
     let (amdgpu_dev, _, _) = {
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let f = File::open(device_path).unwrap();
 
-        libdrm_amdgpu.init_device_handle(f.into_raw_fd()).unwrap()
+        libdrm_amdgpu.init_device_handle(f.as_raw_fd()).unwrap()
     };
 
     let path = amdgpu_dev.get_sysfs_path().unwrap();

--- a/examples/pp_table.rs
+++ b/examples/pp_table.rs
@@ -6,11 +6,11 @@ fn main() {
     let libdrm_amdgpu = LibDrmAmdgpu::new().unwrap();
     let device_path = std::env::var("AMDGPU_PATH").unwrap_or("/dev/dri/renderD128".to_string());
     let (amdgpu_dev, _, _) = {
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let f = File::open(device_path).unwrap();
 
-        libdrm_amdgpu.init_device_handle(f.into_raw_fd()).unwrap()
+        libdrm_amdgpu.init_device_handle(f.as_raw_fd()).unwrap()
     };
 
     let sysfs = amdgpu_dev.get_sysfs_path().unwrap();

--- a/examples/stable_pstate.rs
+++ b/examples/stable_pstate.rs
@@ -6,11 +6,11 @@ fn info(pci_bus: &PCI::BUS_INFO) {
     let Ok(device_path) = pci_bus.get_drm_render_path() else { return };
     let (amdgpu_dev, _major, _minor) = {
         use std::fs::File;
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let fd = File::open(device_path).unwrap();
 
-        libdrm_amdgpu.init_device_handle(fd.into_raw_fd()).unwrap()
+        libdrm_amdgpu.init_device_handle(fd.as_raw_fd()).unwrap()
     };
 
     let ext_info = amdgpu_dev.device_info().unwrap();

--- a/examples/vbios_dump.rs
+++ b/examples/vbios_dump.rs
@@ -18,11 +18,11 @@ fn main() {
     let libdrm_amdgpu = LibDrmAmdgpu::new().unwrap();
     let device_path = std::env::var("AMDGPU_PATH").unwrap_or("/dev/dri/renderD128".to_string());
     let (amdgpu_dev, _, _) = {
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let f = File::open(device_path).unwrap();
 
-        libdrm_amdgpu.init_device_handle(f.into_raw_fd()).unwrap()
+        libdrm_amdgpu.init_device_handle(f.as_raw_fd()).unwrap()
     };
 
     if let Ok(vbios) = amdgpu_dev.get_vbios_info() {

--- a/examples/vbios_parser.rs
+++ b/examples/vbios_parser.rs
@@ -7,11 +7,11 @@ fn main() {
     let libdrm_amdgpu = LibDrmAmdgpu::new().unwrap();
     let device_path = std::env::var("AMDGPU_PATH").unwrap_or("/dev/dri/renderD128".to_string());
     let (amdgpu_dev, _, _) = {
-        use std::os::fd::IntoRawFd;
+        use std::os::fd::AsRawFd;
 
         let f = File::open(device_path).unwrap();
 
-        libdrm_amdgpu.init_device_handle(f.into_raw_fd()).unwrap()
+        libdrm_amdgpu.init_device_handle(f.as_raw_fd()).unwrap()
     };
 
     let Ok(vbios_image) = amdgpu_dev.get_vbios_image() else { return };


### PR DESCRIPTION
When `.into_raw_fd()` is called, it returns a raw file descriptor, with the assumption that the user will manually manage the descriptor's lifetime and call `close()` on it when needed.

On amdgpu device initialization, libdrm [clones the provided descriptor](https://gitlab.freedesktop.org/mesa/libdrm/-/blob/main/amdgpu/amdgpu_device.c?ref_type=heads#L255), and from there on manages its own copy (including closing it on `amdgpu_device_deinitialize`).

The descriptor that was used for initialization never gets cleaned up however, as that is the user's responsibility, so using `.into_raw_fd()` the way it's used in the examples will cause a leak.

Using `.as_raw_fd()` borrows from `File` instead of moving it out it, so with this the "init" descriptor gets freed when the `File` it goes out of scope.