### PR TITLE
Use-after-free bug in drmModeRes, drmModeConnector, drmModeObjectProperties, drmModeProperty and drmModePropertyBlob

### DIFF
--- a/drm_mode/connector.rs
+++ b/drm_mode/connector.rs
@@ -3,7 +3,6 @@ use crate::drmModeObjectProperties;
 use core::ptr::addr_of;
 pub use bindings::{drmModeConnectorPtr, drmModeModeInfo};
 
-#[derive(Clone)]
 pub struct drmModeConnector {
     pub(crate) ptr: drmModeConnectorPtr,
     pub(crate) lib: LibDrm,

--- a/drm_mode/object_property.rs
+++ b/drm_mode/object_property.rs
@@ -4,7 +4,6 @@ use core::ptr::addr_of;
 pub use bindings::drmModeObjectPropertiesPtr;
 use crate::drmModeProperty;
 
-#[derive(Clone)]
 pub struct drmModeObjectProperties {
     pub(crate) ptr: drmModeObjectPropertiesPtr,
     pub(crate) lib: LibDrm,

--- a/drm_mode/property.rs
+++ b/drm_mode/property.rs
@@ -4,7 +4,6 @@ use core::ptr::addr_of;
 pub use bindings::{drmModePropertyPtr, drm_mode_property_enum};
 
 #[allow(dead_code)]
-#[derive(Clone)]
 pub struct drmModeProperty {
     pub(crate) ptr: drmModePropertyPtr,
     pub(crate) lib: LibDrm,

--- a/drm_mode/property_blob.rs
+++ b/drm_mode/property_blob.rs
@@ -4,7 +4,6 @@ use core::ptr::addr_of;
 pub use bindings::drmModePropertyBlobPtr;
 
 #[allow(dead_code)]
-#[derive(Clone)]
 pub struct drmModePropertyBlob {
     pub(crate) ptr: drmModePropertyBlobPtr,
     pub(crate) lib: LibDrm,

--- a/drm_mode/resource.rs
+++ b/drm_mode/resource.rs
@@ -3,7 +3,6 @@ use core::ptr::addr_of;
 
 pub use bindings::{drmModeResPtr, drmModeObjectPropertiesPtr, drmModePropertyPtr};
 
-#[derive(Clone)]
 pub struct drmModeRes {
     pub(crate) ptr: drmModeResPtr,
     pub(crate) lib: LibDrm,


### PR DESCRIPTION
The following types have a `#[derive(Clone)]` over a raw pointer and a `Drop` implementation which unconditionally frees the memory referenced by the pointer:
- `drmModeRes`
- `drmModeConnector` 
- `drmModeObjectProperties`
- `drmModeProperty`
- `drmModePropertyBlob`

`#[derive(Clone)]` performs a bitwise copy on raw pointers. Creating an instance of one of these types, cloning that instance and then dropping both the clone and original causes a use-after-free.

## Reproduction:

```rust
#[test]
fn uaf_drmModeRes() {
    let lib = LibDrm::new().expect("failed to load libdrm");
    let file = OpenOptions::new()
        .read(true)
        .write(true)
        .open("/dev/dri/card1")
        .expect("open /dev/dri/card1 (need root / video group)");
    let a = lib
        .get_drm_mode_resources(file.as_raw_fd())
        .expect("no KMS resources on this fd");
    let b = a.clone();

    drop(a); // drmModeFreeResources(ptr)
    drop(b); // SAME ptr, freed again
}
```

### Verifying with valgrind:

```
cargo build --release --test repro
sudo valgrind --leak-check=no target/release/deps/repro-<HASH> uaf_drmModeRes 
```

Valgrind output:
```
==441181== Memcheck, a memory error detector
==441181== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==441181== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==441181== Command: target/release/deps/repro-f5687fd89a878e65 uaf_drmModeRes
==441181==

running 1 test
==441181== Thread 2 uaf_drmModeRes:
==441181== Invalid read of size 8
==441181==    at 0x4888885: drmModeFreeResources (in /usr/lib/x86_64-linux-gnu/libdrm.so.2.125.0)
```


## Fix: 
- Remove `#[derive(Clone)]` from the buggy types
- I don't think `Clone` is needed on these types but I could be wrong, if `Clone` is needed you might want to write an implementation which does not perform a bitwise copy on raw pointers.
